### PR TITLE
Decouple update rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   iarc7_msgs
+  message_filters
   roscpp
   tf
   tf2

--- a/include/iarc7_sensors/AltimeterFilter.hpp
+++ b/include/iarc7_sensors/AltimeterFilter.hpp
@@ -35,7 +35,6 @@ class AltimeterFilter {
     ~AltimeterFilter() = default;
 
     void updateFilter(const iarc7_msgs::Float64Stamped& msg);
-    double getFilteredAltitude(ros::Time time) const;
 
   private:
     const std::string altimeter_frame_;
@@ -49,8 +48,6 @@ class AltimeterFilter {
 
     message_filters::Subscriber<iarc7_msgs::Float64Stamped> msg_sub_;
     tf2_ros::MessageFilter<iarc7_msgs::Float64Stamped> msg_filter_;
-
-    iarc7_sensors::MovingAverage filter_;
 };
 
 } // namespace iarc7_sensors

--- a/include/iarc7_sensors/AltimeterFilter.hpp
+++ b/include/iarc7_sensors/AltimeterFilter.hpp
@@ -28,7 +28,6 @@ namespace iarc7_sensors {
 class AltimeterFilter {
   public:
     AltimeterFilter(ros::NodeHandle& nh,
-                    const ros::NodeHandle& private_nh,
                     const std::string& altimeter_frame,
                     double altitude_covariance,
                     const std::string& level_quad_frame);

--- a/include/iarc7_sensors/AltimeterFilter.hpp
+++ b/include/iarc7_sensors/AltimeterFilter.hpp
@@ -27,7 +27,8 @@ namespace iarc7_sensors {
 
 class AltimeterFilter {
   public:
-    AltimeterFilter(ros::NodeHandle& node_handle,
+    AltimeterFilter(ros::NodeHandle& nh,
+                    const ros::NodeHandle& private_nh,
                     const std::string& altimeter_frame,
                     double altitude_covariance,
                     const std::string& level_quad_frame);

--- a/include/iarc7_sensors/AltimeterFilter.hpp
+++ b/include/iarc7_sensors/AltimeterFilter.hpp
@@ -9,29 +9,45 @@
 #define IARC7_SENSORS_ALTIMETER_FILTER_H_
 
 #include <ros/ros.h>
+#include <message_filters/subscriber.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <tf2_ros/message_filter.h>
+#pragma GCC diagnostic pop
+
 #include <tf2_ros/transform_listener.h>
 
 #include "iarc7_sensors/MovingAverage.hpp"
+
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <iarc7_msgs/Float64Stamped.h>
 
 namespace iarc7_sensors {
 
 class AltimeterFilter {
   public:
-    AltimeterFilter(const ros::NodeHandle& node_handle,
+    AltimeterFilter(ros::NodeHandle& node_handle,
                     const std::string& altimeter_frame,
+                    double altitude_covariance,
                     const std::string& level_quad_frame);
     ~AltimeterFilter() = default;
 
-    void updateFilter(double altitude, double velocity, ros::Time time);
+    void updateFilter(const iarc7_msgs::Float64Stamped& msg);
     double getFilteredAltitude(ros::Time time) const;
 
   private:
-    ros::NodeHandle node_handle_;
+    const std::string altimeter_frame_;
+    const double altitude_covariance_;
+    const std::string level_quad_frame_;
+
+    const ros::Publisher altitude_pose_pub_;
+
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;
 
-    std::string altimeter_frame_;
-    std::string level_quad_frame_;
+    message_filters::Subscriber<iarc7_msgs::Float64Stamped> msg_sub_;
+    tf2_ros::MessageFilter<iarc7_msgs::Float64Stamped> msg_filter_;
 
     iarc7_sensors::MovingAverage filter_;
 };

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>iarc7_msgs</build_depend>
   <build_depend>libi2c-dev</build_depend>
+  <build_depend>message_filters</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
@@ -50,6 +51,7 @@
   <build_depend>tf2_ros</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>iarc7_msgs</run_depend>
+  <run_depend>message_filters</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2</run_depend>

--- a/param/altimeter.yaml
+++ b/param/altimeter.yaml
@@ -1,1 +1,1 @@
-altitude_covariance: 3.0
+altitude_covariance: 0.50

--- a/src/AltimeterFilter.cpp
+++ b/src/AltimeterFilter.cpp
@@ -22,7 +22,6 @@ T getParam(const ros::NodeHandle& nh, const std::string& name, const T& def) {
 namespace iarc7_sensors {
 
 AltimeterFilter::AltimeterFilter(ros::NodeHandle& nh,
-                                 const ros::NodeHandle& private_nh,
                                  const std::string& altimeter_frame,
                                  double altitude_covariance,
                                  const std::string& level_quad_frame)

--- a/src/AltimeterFilter.cpp
+++ b/src/AltimeterFilter.cpp
@@ -21,44 +21,70 @@ T getParam(const ros::NodeHandle& nh, const std::string& name, const T& def) {
 
 namespace iarc7_sensors {
 
-AltimeterFilter::AltimeterFilter(const ros::NodeHandle& node_handle,
+AltimeterFilter::AltimeterFilter(ros::NodeHandle& node_handle,
                                  const std::string& altimeter_frame,
+                                 double altitude_covariance,
                                  const std::string& level_quad_frame)
-      : node_handle_(node_handle), tf_listener_(tf_buffer_),
-        altimeter_frame_(altimeter_frame), level_quad_frame_(level_quad_frame),
-        filter_(ros::Duration(getParam(node_handle_,
+      : altimeter_frame_(altimeter_frame),
+        altitude_covariance_(altitude_covariance),
+        level_quad_frame_(level_quad_frame),
+        altitude_pose_pub_(
+            node_handle.advertise<geometry_msgs::PoseWithCovarianceStamped>(
+                "altimeter_pose", 0)),
+        tf_buffer_(),
+        tf_listener_(tf_buffer_),
+        msg_sub_(node_handle, "altimeter_reading", 100),
+        msg_filter_(msg_sub_, tf_buffer_, level_quad_frame, 100, nullptr),
+        filter_(ros::Duration(getParam(node_handle,
                                        "filter_time_constant",
-                                       0.0))) {
+                                       0.0)))
+{
+    msg_filter_.registerCallback(&AltimeterFilter::updateFilter, this);
 }
 
-void AltimeterFilter::updateFilter(double altitude,
-                                   double velocity,
-                                   ros::Time time) {
+void AltimeterFilter::updateFilter(const iarc7_msgs::Float64Stamped& msg)
+{
+    ros::Time time = msg.header.stamp;
 
     geometry_msgs::PointStamped altimeter_frame_msg;
     altimeter_frame_msg.header.stamp = time;
     altimeter_frame_msg.header.frame_id = altimeter_frame_;
-    altimeter_frame_msg.point.x = altitude;
+    altimeter_frame_msg.point.x = msg.data;
 
     geometry_msgs::PointStamped level_frame_msg;
 
     try {
-        tf_buffer_.transform(altimeter_frame_msg,
-                             level_frame_msg,
-                             level_quad_frame_,
-                             ros::Duration(0.5));
+        tf_buffer_.transform(altimeter_frame_msg, level_frame_msg, level_quad_frame_);
     } catch (const std::exception& ex) {
         ROS_ERROR("Exception looking up transform in AltimeterFilter: %s",
                   ex.what());
         return;
     }
 
-    double transformed_velocity = velocity * (-level_frame_msg.point.z) / altitude;
+    filter_.updateFilter(-level_frame_msg.point.z, 0.0, time);
 
-    filter_.updateFilter(-level_frame_msg.point.z, transformed_velocity, time);
+    // Publish pose estimate
+    geometry_msgs::PoseWithCovarianceStamped altimeter_pose_msg;
+    altimeter_pose_msg.header.frame_id = "map";
+    altimeter_pose_msg.header.stamp = time;
+    altimeter_pose_msg.pose.pose.position.z = getFilteredAltitude(time);
+
+    // This is a 6x6 matrix and z height is variable 2,
+    // so the z height covariance is at location (2,2)
+    altimeter_pose_msg.pose.covariance[2*6 + 2] = altitude_covariance_ * (1 + 8*std::exp(-4*altimeter_pose_msg.pose.pose.position.z));
+
+    // Check if the filter spit out a valid estimate
+    if (!std::isfinite(altimeter_pose_msg.pose.pose.position.z)) {
+        ROS_ERROR("Altimeter filter returned invalid altitude %f",
+                  altimeter_pose_msg.pose.pose.position.z);
+    } else {
+        // Publish the transform
+        altitude_pose_pub_.publish(altimeter_pose_msg);
+    }
 }
 
-double AltimeterFilter::getFilteredAltitude(ros::Time time) const {
+double AltimeterFilter::getFilteredAltitude(ros::Time time) const
+{
     return filter_.getFilteredValue(time);
 }
 

--- a/src/AltimeterFilter.cpp
+++ b/src/AltimeterFilter.cpp
@@ -21,7 +21,8 @@ T getParam(const ros::NodeHandle& nh, const std::string& name, const T& def) {
 
 namespace iarc7_sensors {
 
-AltimeterFilter::AltimeterFilter(ros::NodeHandle& node_handle,
+AltimeterFilter::AltimeterFilter(ros::NodeHandle& nh,
+                                 const ros::NodeHandle& private_nh,
                                  const std::string& altimeter_frame,
                                  double altitude_covariance,
                                  const std::string& level_quad_frame)
@@ -29,13 +30,13 @@ AltimeterFilter::AltimeterFilter(ros::NodeHandle& node_handle,
         altitude_covariance_(altitude_covariance),
         level_quad_frame_(level_quad_frame),
         altitude_pose_pub_(
-            node_handle.advertise<geometry_msgs::PoseWithCovarianceStamped>(
+            nh.advertise<geometry_msgs::PoseWithCovarianceStamped>(
                 "altimeter_pose", 0)),
         tf_buffer_(),
         tf_listener_(tf_buffer_),
-        msg_sub_(node_handle, "altimeter_reading", 100),
+        msg_sub_(nh, "altimeter_reading", 100),
         msg_filter_(msg_sub_, tf_buffer_, level_quad_frame, 100, nullptr),
-        filter_(ros::Duration(getParam(node_handle,
+        filter_(ros::Duration(getParam(private_nh,
                                        "filter_time_constant",
                                        0.0)))
 {

--- a/src/AltimeterFilter.cpp
+++ b/src/AltimeterFilter.cpp
@@ -66,7 +66,7 @@ void AltimeterFilter::updateFilter(const iarc7_msgs::Float64Stamped& msg)
 
     // This is a 6x6 matrix and z height is variable 2,
     // so the z height covariance is at location (2,2)
-    altimeter_pose_msg.pose.covariance[2*6 + 2] = altitude_covariance_ * (1 + 8*std::exp(-4*altimeter_pose_msg.pose.pose.position.z));
+    altimeter_pose_msg.pose.covariance[2*6 + 2] = altitude_covariance_ * (1 + 60*std::exp(-250*std::pow(altimeter_pose_msg.pose.pose.position.z, 4)));
 
     // Check if the filter spit out a valid estimate
     if (!std::isfinite(altimeter_pose_msg.pose.pose.position.z)) {

--- a/src/altimeter.cpp
+++ b/src/altimeter.cpp
@@ -56,7 +56,6 @@ int main(int argc, char **argv) {
 
     LidarLite lidarLite;
     iarc7_sensors::AltimeterFilter filter(n,
-                                          private_nh,
                                           altitude_frame,
                                           altitude_covariance,
                                           "level_quad");

--- a/src/altimeter.cpp
+++ b/src/altimeter.cpp
@@ -55,7 +55,8 @@ int main(int argc, char **argv) {
         n.advertise<iarc7_msgs::Float64Stamped>("velocity", 0);
 
     LidarLite lidarLite;
-    iarc7_sensors::AltimeterFilter filter(private_nh,
+    iarc7_sensors::AltimeterFilter filter(n,
+                                          private_nh,
                                           altitude_frame,
                                           altitude_covariance,
                                           "level_quad");


### PR DESCRIPTION
Make the altimeter update independently of the tf update frequency.  It now pushes data at around 90Hz.

Already tested on the quad.